### PR TITLE
Improve radio robustness and packet format; add smoothing, safety and Python controller refactors

### DIFF
--- a/ESP32/RxCompleto/RxCompleto.ino
+++ b/ESP32/RxCompleto/RxCompleto.ino
@@ -1,94 +1,91 @@
 /*
- * RxCompleto.ino — Ricezione Squadra Corse
- *
- * Pacchetto radio 9 byte:
- *   [0-3] Token "VAL1"
- *   [4]   Sterzo        (0-255, 128 = centro)
- *   [5]   Accelerazione (0-255)
- *   [6]   speed_sel:4 | brake:1 | reverse:1 | comandi:2
- *   [7-8] CRC-16 CCITT  (big-endian, su byte 0-6)
- *
- * Hot-swap hardware: il modulo viene sostituito fisicamente.
- * Il RX ri-proba periodicamente (ogni PROBE_INTERVAL_MS) e
- * si adatta automaticamente al modulo presente.
+ * RxCompleto.ino — Ricezione Squadra Corse (robust link)
  */
 
 #include <SPI.h>
 #include <ESP32Servo.h>
-
-// ==================== LoRa ====================
 #include <LoRa.h>
+#include <nRF24L01.h>
+#include <RF24.h>
+
 #define LORA_SCK    18
 #define LORA_MISO   19
 #define LORA_MOSI   23
 #define LORA_CS      5
 #define LORA_RST    21
 
-// ==================== nRF24 ====================
-#include <nRF24L01.h>
-#include <RF24.h>
-RF24 radio(2, 4);                       // CE=2, CSN=4
-const byte nrfAddress[6] = "00001"; 
+RF24 radio(2, 4);
+const byte nrfAddress[6] = "00001";
 
-// ==================== Servo ====================
 #define SERVO_PIN       26
 const int SERVO_CENTER = 90;
 
-// ==================== Motore ====================
+// MOTORE: PIN INVARIATI
 #define PWM_PIN         25
 #define DIR_FWD_PIN     33
 #define DIR_REV_PIN     32
 #define PWM_FREQ      1000
-#define PWM_RES          8      // 8 bit → 0-255
+#define PWM_RES          8
 
-// ============== CONFIGURAZIONE ==============
-#define STEER_ANGLE_MAX     45
-#define REVERSE_MULTIPLIER   0.5f
-#define DEADZONE             0.08f
-#define FAILSAFE_MS          500
-#define PROBE_INTERVAL_MS   2000        // ms tra un probe e l'altro
-#define PACKET_SIZE           9
+#define STEER_ANGLE_MAX        45
+#define DEADZONE            0.06f
+#define PACKET_SIZE            10
+#define PROBE_INTERVAL_MS    2000
+#define LINK_TIMEOUT_MS       350
+#define FAILSAFE_MS          1200
+#define MOTOR_TICK_MS          20
+#define STATS_INTERVAL_MS    5000
+#define DEBUG_SERIAL        false
 
 Servo servo;
 
-// ==================== STATO ====================
 enum RadioType { RADIO_NONE, RADIO_LORA, RADIO_NRF24 };
 RadioType activeRadio = RADIO_NONE;
 
-unsigned long lastPacketTime      = 0;
-unsigned long lastProbeMs         = 0;
-unsigned long lastVelocityUpdate  = 0;
-float lastSteerNorm = 0.0f;
+unsigned long lastPacketTime = 0;
+unsigned long lastProbeMs = 0;
+unsigned long lastVelocityUpdate = 0;
+unsigned long lastStatsMs = 0;
 
-// ── Stato motore ──
-bool    rx_freno             = false;
-bool    rx_retro             = false;
-uint8_t rx_pressione_pedale  = 0;
-float   velocita_target      = 0;
-float   velocita_attuale     = 0;
-bool    freno_premuto        = false;
+float steer_target_norm = 0.0f;
+float steer_current_norm = 0.0f;
 
-// ==================== CRC-16 ====================
+bool    rx_freno = false;
+bool    rx_retro = false;
+uint8_t rx_pressione_pedale = 0;
+float   velocita_target = 0;
+float   velocita_attuale = 0;
+
+bool hasSeq = false;
+uint8_t lastSeq = 0;
+
+uint32_t statPktOk = 0;
+uint32_t statCrcErr = 0;
+uint32_t statTokenErr = 0;
+uint32_t statDup = 0;
+uint32_t statLost = 0;
+
 uint16_t crc16_ccitt(const uint8_t *data, uint8_t len) {
   uint16_t crc = 0xFFFF;
   for (uint8_t i = 0; i < len; i++) {
     crc ^= (uint16_t)data[i] << 8;
-    for (uint8_t j = 0; j < 8; j++)
-      crc = (crc & 0x8000) ? (crc << 1) ^ 0x1021 : crc << 1;
+    for (uint8_t j = 0; j < 8; j++) crc = (crc & 0x8000) ? (crc << 1) ^ 0x1021 : crc << 1;
   }
   return crc;
 }
 
-// ============== INIT MODULI RADIO ==============
 bool initLoRa() {
   SPI.end();
   SPI.begin(LORA_SCK, LORA_MISO, LORA_MOSI, LORA_CS);
   LoRa.setPins(LORA_CS, LORA_RST, -1);
   if (!LoRa.begin(433E6)) return false;
-  LoRa.setSpreadingFactor(7);
-  LoRa.setSignalBandwidth(250E3);
-  LoRa.setCodingRate4(5);
-  LoRa.setPreambleLength(6);
+
+  LoRa.setSpreadingFactor(9);
+  LoRa.setSignalBandwidth(125E3);
+  LoRa.setCodingRate4(8);
+  LoRa.setPreambleLength(10);
+  LoRa.setSyncWord(0x12);
+  LoRa.enableCrc();
   return true;
 }
 
@@ -101,37 +98,34 @@ bool initNRF24() {
   radio.setPALevel(RF24_PA_MAX);
   radio.setDataRate(RF24_250KBPS);
   radio.setPayloadSize(PACKET_SIZE);
+  radio.setAutoAck(true);
   radio.openReadingPipe(1, nrfAddress);
   radio.startListening();
   return true;
 }
 
 RadioType detectRadio() {
-  if (initLoRa())  return RADIO_LORA;
+  if (initLoRa()) return RADIO_LORA;
   if (initNRF24()) return RADIO_NRF24;
   return RADIO_NONE;
 }
 
 const char *radioName() {
   switch (activeRadio) {
-    case RADIO_LORA:  return "LORA";
+    case RADIO_LORA: return "LORA";
     case RADIO_NRF24: return "NRF24";
-    default:          return "NONE";
+    default: return "NONE";
   }
 }
 
-// ========== PROBE PERIODICO ==========
 void probeRadio() {
   RadioType prev = activeRadio;
-
   bool stillAlive = false;
-  if (prev == RADIO_LORA)  stillAlive = initLoRa();
+
+  if (prev == RADIO_LORA) stillAlive = initLoRa();
   else if (prev == RADIO_NRF24) stillAlive = initNRF24();
 
-  if (stillAlive) {
-    activeRadio = prev;
-    return;
-  }
+  if (stillAlive) return;
 
   RadioType found = detectRadio();
   activeRadio = found;
@@ -142,64 +136,77 @@ void probeRadio() {
   }
 }
 
-// ========== ELABORAZIONE PACCHETTO ==========
+void updateSteering() {
+  // Sterzo costante: mantiene target finché non arriva un nuovo comando.
+  const float steer_step = 0.04f;
+  if (steer_current_norm < steer_target_norm) steer_current_norm = min(steer_target_norm, steer_current_norm + steer_step);
+  else if (steer_current_norm > steer_target_norm) steer_current_norm = max(steer_target_norm, steer_current_norm - steer_step);
+
+  int angle = SERVO_CENTER + (int)(steer_current_norm * STEER_ANGLE_MAX);
+  angle = constrain(angle, SERVO_CENTER - STEER_ANGLE_MAX, SERVO_CENTER + STEER_ANGLE_MAX);
+  servo.write(angle);
+}
+
 void processPacket(const uint8_t *buf, int rssi) {
-  if (buf[0] != 'V' || buf[1] != 'A' || buf[2] != 'L' || buf[3] != '1') {
-    Serial.println("TOKEN_ERR");
+  if (buf[0] != 'V' || buf[1] != 'A' || buf[2] != 'L' || buf[3] != '2') {
+    statTokenErr++;
     return;
   }
 
-  uint16_t rxCrc   = ((uint16_t)buf[7] << 8) | buf[8];
-  uint16_t calcCrc = crc16_ccitt(buf, 7);
+  uint16_t rxCrc = ((uint16_t)buf[8] << 8) | buf[9];
+  uint16_t calcCrc = crc16_ccitt(buf, 8);
   if (rxCrc != calcCrc) {
-    Serial.println("CRC_ERR");
+    statCrcErr++;
     return;
   }
+
+  uint8_t seq = buf[7];
+  if (hasSeq) {
+    uint8_t delta = (uint8_t)(seq - lastSeq);
+    if (delta == 0) {
+      statDup++;
+      lastPacketTime = millis();
+      return;
+    }
+    if (delta > 1) statLost += (uint32_t)(delta - 1);
+  }
+  hasSeq = true;
+  lastSeq = seq;
 
   lastPacketTime = millis();
+  statPktOk++;
 
   uint8_t steerByte = buf[4];
   uint8_t accelByte = buf[5];
-  uint8_t miscByte  = buf[6];
+  uint8_t miscByte = buf[6];
 
-  //uint8_t speedSel  = (miscByte >> 4) & 0x0F;
-  bool    brake     = (miscByte >> 3) & 0x01;
-  bool    reverse   = (miscByte >> 2) & 0x01;
-  uint8_t commands  = miscByte & 0x03;
-
-  // ── Sterzo → servo ──
   float steerNorm = ((float)steerByte - 128.0f) / 127.0f;
   steerNorm = constrain(steerNorm, -1.0f, 1.0f);
   if (fabs(steerNorm) < DEADZONE) steerNorm = 0.0f;
+  steer_target_norm = steerNorm;
 
-  if (fabs(steerNorm - lastSteerNorm) >= 0.02f) {
-    lastSteerNorm = steerNorm;
-    int angle = SERVO_CENTER + (int)(steerNorm * STEER_ANGLE_MAX);
-    angle = constrain(angle,
-                      SERVO_CENTER - STEER_ANGLE_MAX,
-                      SERVO_CENTER + STEER_ANGLE_MAX);
-    servo.write(angle);
-  }
-
-  // ── Aggiorna stato motore ──
-  rx_freno            = brake;
-  rx_retro            = reverse;
+  rx_freno = ((miscByte >> 3) & 0x01);
+  rx_retro = ((miscByte >> 2) & 0x01);
   rx_pressione_pedale = accelByte;
-  //rx_marcia           = map(speedSel, 0, 15, 1, MAX_SPEEDS);
 
-  // ── Output seriale ──
-  Serial.print("S:");   Serial.print(steerNorm, 2);
-  Serial.print(" A:");  Serial.print((float)accelByte / 255.0f, 2);
-  Serial.print(" B:");  Serial.print(brake ? "Y" : "N");
-  Serial.print(" R:");  Serial.print(reverse ? "Y" : "N");
-  Serial.print(" C:");  Serial.print(commands);
-  if (activeRadio == RADIO_LORA) {
-    Serial.print(" RSSI:"); Serial.print(rssi);
+  if (DEBUG_SERIAL && activeRadio == RADIO_LORA) {
+    Serial.print("RSSI:");
+    Serial.print(rssi);
+    Serial.print(" ");
   }
-  Serial.println();
 }
 
-// ======================== SETUP ========================
+void hardStop() {
+  velocita_attuale = 0;
+  velocita_target = 0;
+  steer_target_norm = 0;
+  steer_current_norm = 0;
+  ledcWrite(PWM_PIN, 0);
+  digitalWrite(DIR_FWD_PIN, LOW);
+  digitalWrite(DIR_REV_PIN, LOW);
+  servo.write(SERVO_CENTER);
+}
+
 void setup() {
   Serial.begin(115200);
   delay(1000);
@@ -208,7 +215,6 @@ void setup() {
   servo.attach(SERVO_PIN, 500, 2400);
   servo.write(SERVO_CENTER);
 
-  // Motore
   ledcAttach(PWM_PIN, PWM_FREQ, PWM_RES);
   pinMode(DIR_FWD_PIN, OUTPUT);
   pinMode(DIR_REV_PIN, OUTPUT);
@@ -217,99 +223,87 @@ void setup() {
 
   activeRadio = detectRadio();
 
-  if (activeRadio == RADIO_NONE) {
-    Serial.println("ERR NO_RADIO");
-    // Non blocchiamo: il probe periodico ritenterà
-  } else {
+  if (activeRadio == RADIO_NONE) Serial.println("ERR NO_RADIO");
+  else {
     Serial.print("RX READY ");
     Serial.println(radioName());
   }
 }
 
-// ======================== LOOP =========================
 void loop() {
-  // ── Probe periodico ──
   unsigned long now = millis();
+
   if (now - lastProbeMs >= PROBE_INTERVAL_MS) {
     lastProbeMs = now;
     probeRadio();
   }
 
-  // ── Failsafe ──
-  if (lastPacketTime > 0 && (millis() - lastPacketTime > FAILSAFE_MS)) {
-    servo.write(SERVO_CENTER);
-    ledcWrite(PWM_PIN, 0);
-    digitalWrite(DIR_FWD_PIN, LOW);
-    digitalWrite(DIR_REV_PIN, LOW);
-    velocita_attuale = 0;
-    velocita_target  = 0;
-    lastPacketTime = 0;
-    Serial.println("FAILSAFE");
-  }
-
-  // ── Ricezione pacchetto ──
   uint8_t buf[PACKET_SIZE] = {0};
-
   if (activeRadio == RADIO_LORA) {
-    int pktSize = LoRa.parsePacket(PACKET_SIZE);
+    int pktSize = LoRa.parsePacket();
     if (pktSize == PACKET_SIZE) {
       for (int i = 0; i < PACKET_SIZE; i++) buf[i] = LoRa.read();
       processPacket(buf, LoRa.packetRssi());
     }
-  }
-  else if (activeRadio == RADIO_NRF24) {
-    if (radio.available()) {
+  } else if (activeRadio == RADIO_NRF24) {
+    while (radio.available()) {
       radio.read(buf, PACKET_SIZE);
       processPacket(buf, 0);
     }
   }
 
-  // ── Aggiornamento velocità e motore (ogni 10 ms) ──
-  if (millis() - lastVelocityUpdate >= 40) {
-    lastVelocityUpdate = millis();
+  if (now - lastVelocityUpdate >= MOTOR_TICK_MS) {
+    lastVelocityUpdate = now;
 
-    // 1. Calcolo velocità target
-    if (rx_freno) {
-      velocita_target = 0;
-      freno_premuto = true;
-    }
-    else if (rx_retro) {
-      // In retro usiamo la pressione del pedale (0-255), divisa per 2 per sicurezza [cite: 115]
-      velocita_target = -((float)rx_pressione_pedale) / 2.0f;
-      freno_premuto = false;
-    }
-    else {
-      // Marcia avanti: mappatura diretta 1:1 dal pedale [cite: 116]
-      velocita_target = (float)rx_pressione_pedale;
-      freno_premuto = false;
+    unsigned long silence = (lastPacketTime == 0) ? FAILSAFE_MS + 1 : (now - lastPacketTime);
+
+    if (silence > FAILSAFE_MS) {
+      hardStop();
+      return;
     }
 
-    // 2. Aggiornamento velocità attuale
-    if (freno_premuto) {
-      if (velocita_attuale > 0)      velocita_attuale -= 2;
-      else if (velocita_attuale < 0) velocita_attuale += 2;
-      if (fabs(velocita_attuale) < 2) velocita_attuale = 0;
-    }
-    else {
-      if (velocita_attuale < velocita_target)      velocita_attuale++;
-      else if (velocita_attuale > velocita_target) velocita_attuale--;
+    if (silence > LINK_TIMEOUT_MS) {
+      rx_freno = true;
+      rx_pressione_pedale = 0;
+      // NON forzare steer_target_norm a zero: evita il ritorno a 0 improvviso in curva.
     }
 
-    // 3. Output motore
+    if (rx_freno) velocita_target = 0;
+    else if (rx_retro) velocita_target = -((float)rx_pressione_pedale) * 0.5f;
+    else velocita_target = (float)rx_pressione_pedale;
+
+    if (velocita_attuale < velocita_target) velocita_attuale += 1.2f;
+    else if (velocita_attuale > velocita_target) velocita_attuale -= (rx_freno ? 2.0f : 1.2f);
+    if (fabs(velocita_attuale) < 1.0f) velocita_attuale = 0;
+
     int pwmVal = constrain(abs((int)velocita_attuale), 0, 255);
     ledcWrite(PWM_PIN, pwmVal);
 
     if (velocita_attuale > 0) {
       digitalWrite(DIR_FWD_PIN, HIGH);
       digitalWrite(DIR_REV_PIN, LOW);
-    }
-    else if (velocita_attuale < 0) {
+    } else if (velocita_attuale < 0) {
       digitalWrite(DIR_FWD_PIN, LOW);
       digitalWrite(DIR_REV_PIN, HIGH);
-    }
-    else {
+    } else {
       digitalWrite(DIR_FWD_PIN, LOW);
       digitalWrite(DIR_REV_PIN, LOW);
     }
+
+    updateSteering();
+  }
+
+  if (DEBUG_SERIAL && now - lastStatsMs >= STATS_INTERVAL_MS) {
+    lastStatsMs = now;
+    Serial.print("RX_STATS ok=");
+    Serial.print(statPktOk);
+    Serial.print(" lost=");
+    Serial.print(statLost);
+    Serial.print(" dup=");
+    Serial.print(statDup);
+    Serial.print(" crc=");
+    Serial.print(statCrcErr);
+    Serial.print(" token=");
+    Serial.println(statTokenErr);
   }
 }

--- a/ESP32/TxCompleto/TxCompleto.ino
+++ b/ESP32/TxCompleto/TxCompleto.ino
@@ -1,80 +1,68 @@
 /*
- * TxCompleto.ino — Trasmissione Squadra Corse
- *
- * Pacchetto radio 9 byte:
- *   [0-3] Token "VAL1"
- *   [4]   Sterzo       (0-255, 128 = centro)
- *   [5]   Accelerazione(0-255)
- *   [6]   speed_sel:4 | brake:1 | reverse:1 | comandi:2
- *   [7-8] CRC-16 CCITT  (big-endian, su byte 0-6)
- *
- * Protocollo USB  (testo, '\n'-terminated):
- *   HANDSHAKE          → ACK <modulo> <rate> [<txpower>]
- *   SET TXPOWER <v>    → OK | ERR …
- *   SET SENDRATE <v>   → OK | ERR …
- *   STATUS             → STATUS <modulo> <rate> [<txpower>]
- *
- * Messaggi asincroni dal TX → PC:
- *   MODULE_CHANGED <modulo> [<txpower>]
- *
- * Hot-swap hardware: il modulo viene sostituito fisicamente.
- * Il TX ri-proba periodicamente e segnala il cambio via USB.
- *
- * Protocollo USB  (binario, 6 byte):
- *   0xAA | sterzo | accel | misc | CRC-16 hi | CRC-16 lo
+ * TxCompleto.ino — Trasmissione Squadra Corse (robust + paced link)
  */
 
-#include <SPI.h>  
-
-// ==================== LoRa ====================
+#include <SPI.h>
 #include <LoRa.h>
+#include <nRF24L01.h>
+#include <RF24.h>
+
 #define LORA_SCK    18
 #define LORA_MISO   19
 #define LORA_MOSI   23
 #define LORA_CS      5
 #define LORA_RST    21
 
-// ==================== nRF24 ====================
-#include <nRF24L01.h>
-#include <RF24.h>
-RF24 radio(2, 4);                       // CE=2, CSN=4
+RF24 radio(2, 4);
 const byte nrfAddress[6] = "00001";
 
-// ================ CONFIGURAZIONE ================
-#define PACKET_SIZE         9
-#define USB_FRAME_SIZE      6
-#define BINARY_MARKER    0xAA
-#define PROBE_INTERVAL_MS 2000          // ogni 2 s controlla se il modulo è cambiato
+#define PACKET_SIZE           10
+#define USB_FRAME_SIZE         6
+#define BINARY_MARKER       0xAA
+#define PROBE_INTERVAL_MS   2000
+#define STATS_INTERVAL_MS   5000
+#define RX_USB_TIMEOUT_MS    350
+#define DEBUG_SERIAL        false
 
-int  loraTxPower  = 20;                 // dBm  (2 – 20)
-int  sendRate     = 20;                 // Hz
+int loraTxPower = 20;
+int sendRate = 35;
 
-// ==================== STATO ====================
 enum RadioType { RADIO_NONE, RADIO_LORA, RADIO_NRF24 };
 RadioType activeRadio = RADIO_NONE;
-unsigned long lastProbeMs = 0;
 
-// ==================== CRC-16 ====================
+unsigned long lastProbeMs = 0;
+unsigned long lastStatsMs = 0;
+unsigned long lastSendMs = 0;
+unsigned long lastUsbFrameMs = 0;
+
+uint8_t txSeq = 0;
+uint8_t latestPayload[3] = {128, 0, 0};
+bool havePayload = false;
+
+uint32_t statSentOk = 0;
+uint32_t statSentFail = 0;
+uint32_t statCrcErrUsb = 0;
+
 uint16_t crc16_ccitt(const uint8_t *data, uint8_t len) {
   uint16_t crc = 0xFFFF;
   for (uint8_t i = 0; i < len; i++) {
     crc ^= (uint16_t)data[i] << 8;
-    for (uint8_t j = 0; j < 8; j++)
-      crc = (crc & 0x8000) ? (crc << 1) ^ 0x1021 : crc << 1;
+    for (uint8_t j = 0; j < 8; j++) crc = (crc & 0x8000) ? (crc << 1) ^ 0x1021 : crc << 1;
   }
   return crc;
 }
 
-// ============== INIT MODULI RADIO ==============
 bool initLoRa() {
   SPI.end();
   SPI.begin(LORA_SCK, LORA_MISO, LORA_MOSI, LORA_CS);
   LoRa.setPins(LORA_CS, LORA_RST, -1);
   if (!LoRa.begin(433E6)) return false;
-  LoRa.setSpreadingFactor(7);
-  LoRa.setSignalBandwidth(250E3);
-  LoRa.setCodingRate4(5);
-  LoRa.setPreambleLength(6);
+  LoRa.setSpreadingFactor(9);
+  LoRa.setSignalBandwidth(125E3);
+  LoRa.setCodingRate4(8);
+  LoRa.setPreambleLength(10);
+  LoRa.setSyncWord(0x12);
+  LoRa.enableCrc();
   LoRa.setTxPower(loraTxPower);
   return true;
 }
@@ -88,6 +76,8 @@ bool initNRF24() {
   radio.setPALevel(RF24_PA_MAX);
   radio.setDataRate(RF24_250KBPS);
   radio.setPayloadSize(PACKET_SIZE);
+  radio.setAutoAck(true);
+  radio.setRetries(5, 15);
   radio.openWritingPipe(nrfAddress);
   radio.stopListening();
   return true;
@@ -95,130 +85,120 @@ bool initNRF24() {
 
 const char *radioName() {
   switch (activeRadio) {
-    case RADIO_LORA:  return "LORA";
+    case RADIO_LORA: return "LORA";
     case RADIO_NRF24: return "NRF24";
-    default:          return "NONE";
+    default: return "NONE";
   }
 }
 
-// ========== DETECT / PROBE ==========
-// Prova a trovare un modulo. Restituisce il tipo trovato.
 RadioType detectRadio() {
-  if (initLoRa())  return RADIO_LORA;
+  if (initLoRa()) return RADIO_LORA;
   if (initNRF24()) return RADIO_NRF24;
   return RADIO_NONE;
 }
 
-// Chiamata periodica: controlla se il modulo HW è cambiato.
 void probeRadio() {
   RadioType prev = activeRadio;
-
-  // Prima controlla se il modulo attuale è ancora presente
   bool stillAlive = false;
-  if (prev == RADIO_LORA) {
-    // LoRa: prova a ri-inizializzare
-    stillAlive = initLoRa();
-  } else if (prev == RADIO_NRF24) {
-    stillAlive = initNRF24();
-  }
 
-  if (stillAlive) {
-    activeRadio = prev;  // tutto OK, modulo invariato
-    return;
-  }
+  if (prev == RADIO_LORA) stillAlive = initLoRa();
+  else if (prev == RADIO_NRF24) stillAlive = initNRF24();
 
-  // Modulo precedente non risponde: prova l'altro
+  if (stillAlive) return;
+
   RadioType found = detectRadio();
   activeRadio = found;
-
   if (found != prev) {
-    // Segnala il cambio via USB
     Serial.print("MODULE_CHANGED ");
-    Serial.print(radioName());
-    if (found == RADIO_LORA) {
-      Serial.print(" ");
-      Serial.print(loraTxPower);
-    }
-    Serial.println();
+    Serial.println(radioName());
   }
 }
 
-// ========== COSTRUZIONE + TRASMISSIONE ==========
 bool transmitPacket(const uint8_t *payload3) {
   uint8_t pkt[PACKET_SIZE];
-  pkt[0] = 'V'; pkt[1] = 'A'; pkt[2] = 'L'; pkt[3] = '1';
+  pkt[0] = 'V'; pkt[1] = 'A'; pkt[2] = 'L'; pkt[3] = '2';
   memcpy(pkt + 4, payload3, 3);
-  uint16_t crc = crc16_ccitt(pkt, 7);
-  pkt[7] = (crc >> 8) & 0xFF;
-  pkt[8] =  crc       & 0xFF;
+  pkt[7] = txSeq++;
+
+  uint16_t crc = crc16_ccitt(pkt, 8);
+  pkt[8] = (crc >> 8) & 0xFF;
+  pkt[9] = crc & 0xFF;
 
   if (activeRadio == RADIO_LORA) {
-    LoRa.beginPacket(true);
+    LoRa.beginPacket();
     LoRa.write(pkt, PACKET_SIZE);
-    LoRa.endPacket(true);
-    return true;
+    return LoRa.endPacket(false) == 1;
   }
-  if (activeRadio == RADIO_NRF24) {
-    return radio.write(pkt, PACKET_SIZE);
-  }
+  if (activeRadio == RADIO_NRF24) return radio.write(pkt, PACKET_SIZE);
   return false;
 }
 
-// ============ GESTIONE COMANDI TESTO ============
 void sendStatus() {
   Serial.print("STATUS ");
   Serial.print(radioName());
   Serial.print(" ");
   Serial.print(sendRate);
-  if (activeRadio == RADIO_LORA) {
-    Serial.print(" ");
-    Serial.print(loraTxPower);
-  }
-  Serial.println();
+  Serial.print(" SENT=");
+  Serial.print(statSentOk);
+  Serial.print(" FAIL=");
+  Serial.println(statSentFail);
 }
 
 void handleCommand(String cmd) {
   cmd.trim();
-
   if (cmd == "HANDSHAKE") {
     Serial.print("ACK ");
     Serial.print(radioName());
     Serial.print(" ");
-    Serial.print(sendRate);
-    if (activeRadio == RADIO_LORA) {
-      Serial.print(" ");
-      Serial.print(loraTxPower);
-    }
-    Serial.println();
-  }
-  else if (cmd.startsWith("SET TXPOWER ")) {
+    Serial.println(sendRate);
+  } else if (cmd.startsWith("SET TXPOWER ")) {
     int v = cmd.substring(12).toInt();
     if (v >= 2 && v <= 20) {
       loraTxPower = v;
       if (activeRadio == RADIO_LORA) LoRa.setTxPower(loraTxPower);
       Serial.println("OK");
-    } else {
-      Serial.println("ERR TXPOWER_RANGE");
-    }
-  }
-  else if (cmd.startsWith("SET SENDRATE ")) {
+    } else Serial.println("ERR TXPOWER_RANGE");
+  } else if (cmd.startsWith("SET SENDRATE ")) {
     int v = cmd.substring(13).toInt();
-    if (v >= 1 && v <= 100) {
+    if (v >= 5 && v <= 100) {
       sendRate = v;
       Serial.println("OK");
-    } else {
-      Serial.println("ERR SENDRATE_RANGE");
-    }
-  }
-  else if (cmd == "STATUS") {
+    } else Serial.println("ERR SENDRATE_RANGE");
+  } else if (cmd == "STATUS") {
     sendStatus();
-  }
-  else {
+  } else {
     Serial.println("ERR UNKNOWN_CMD");
   }
 }
 
-// ======================== SETUP ========================
+void handleUsbInput() {
+  while (Serial.available() > 0) {
+    uint8_t first = Serial.peek();
+    if (first == BINARY_MARKER) {
+      if (Serial.available() < USB_FRAME_SIZE) return;
+
+      uint8_t frame[USB_FRAME_SIZE];
+      Serial.readBytes(frame, USB_FRAME_SIZE);
+
+      uint16_t rxCrc = ((uint16_t)frame[4] << 8) | frame[5];
+      uint16_t calcCrc = crc16_ccitt(frame + 1, 3);
+      if (rxCrc != calcCrc) {
+        statCrcErrUsb++;
+        continue;
+      }
+
+      latestPayload[0] = frame[1];
+      latestPayload[1] = frame[2];
+      latestPayload[2] = frame[3];
+      havePayload = true;
+      lastUsbFrameMs = millis();
+    } else {
+      String cmd = Serial.readStringUntil('\n');
+      handleCommand(cmd);
+    }
+  }
+}
+
 void setup() {
   Serial.begin(115200);
   delay(1000);
@@ -228,47 +208,37 @@ void setup() {
   Serial.println("READY");
 }
 
-// ======================== LOOP =========================
 void loop() {
-  // ── Probe periodico modulo HW ──
   unsigned long now = millis();
+
   if (now - lastProbeMs >= PROBE_INTERVAL_MS) {
     lastProbeMs = now;
     probeRadio();
   }
 
-  // ── Seriale USB ──
-  if (Serial.available() == 0) { delay(1); return; }
+  handleUsbInput();
 
-  uint8_t first = Serial.peek();
-
-  // ---------- frame binario ----------
-  if (first == BINARY_MARKER) {
-    if (Serial.available() < USB_FRAME_SIZE) { delay(1); return; }
-
-    uint8_t frame[USB_FRAME_SIZE];
-    Serial.readBytes(frame, USB_FRAME_SIZE);
-
-    uint16_t rxCrc   = ((uint16_t)frame[4] << 8) | frame[5];
-    uint16_t calcCrc = crc16_ccitt(frame + 1, 3);
-
-    if (rxCrc != calcCrc) {
-      Serial.println("CRC_ERR");
-      while (Serial.available()) Serial.read();
-      return;
-    }
-
-    if (activeRadio == RADIO_NONE) {
-      Serial.println("NO_RADIO");
-      return;
-    }
-
-    bool ok = transmitPacket(frame + 1);
-    if (!ok) Serial.println("TX_FAIL");
+  if (havePayload && (now - lastUsbFrameMs > RX_USB_TIMEOUT_MS)) {
+    // Mantieni sterzo e direzione; taglia solo accelerazione per sicurezza morbida.
+    latestPayload[1] = 0;
+    latestPayload[2] |= (1 << 3);
   }
-  // ---------- comando testo ----------
-  else {
-    String cmd = Serial.readStringUntil('\n');
-    handleCommand(cmd);
+
+  unsigned long intervalMs = (sendRate > 0) ? (1000UL / (unsigned long)sendRate) : 30;
+  if (havePayload && now - lastSendMs >= intervalMs) {
+    lastSendMs = now;
+    if (activeRadio == RADIO_NONE) statSentFail++;
+    else if (transmitPacket(latestPayload)) statSentOk++;
+    else statSentFail++;
+  }
+
+  if (DEBUG_SERIAL && now - lastStatsMs >= STATS_INTERVAL_MS) {
+    lastStatsMs = now;
+    Serial.print("TX_STATS ok=");
+    Serial.print(statSentOk);
+    Serial.print(" fail=");
+    Serial.print(statSentFail);
+    Serial.print(" usb_crc=");
+    Serial.println(statCrcErrUsb);
   }
 }

--- a/src/objController.py
+++ b/src/objController.py
@@ -1,65 +1,70 @@
-import pygame
 import argparse
 import sys
 import time
-from colorama import *
-from src.utils import *
+
+import pygame
+from colorama import Fore, Style, init
+
 from src.objRadio import RadioController
+from src.utils import (
+    CLEAR,
+    INIZIALISE,
+    drawMenu,
+    drawSettingOption,
+    drawSettings,
+    loadMap,
+    loadWorkSpace,
+    presetMenu,
+    readfile,
+    reloadPreset,
+    setUpVolante,
+    settingOption,
+)
 
 init(autoreset=True)
 
-# Definizioni costanti per mappatura e menu
 button_list = ["START", "EXIT", "SETTINGS", "UP", "DOWN", "SELECT", "RETRO_ON", "RETRO_OFF"]
 axis_list = ["STEERING", "ACCELERATOR", "BRAKE"]
-options_list = ["Regolazione massima velocità", 
-                "Regolazione angolo massimo sterzo", 
-                "Reset mappatura tasti",
-                "Salva preset impostazioni"]
+options_list = [
+    "Regolazione massima velocità",
+    "Regolazione angolo massimo sterzo",
+    "Reset mappatura tasti",
+    "Salva preset impostazioni",
+]
 
-class Controller():
+
+class Controller:
     def __init__(self):
         pygame.init()
         pygame.joystick.init()
 
-        if pygame.joystick.get_count() == 0:
-            print(Fore.RED + "ERRORE: Nessun controller trovato." + Style.RESET_ALL)
-            pygame.quit()
-            quit()
+        self.js = self._connect_first_joystick()
 
-        self.js = pygame.joystick.Joystick(0)
-        self.js.init()
-
-        # --- Caricamento Workspace e Preset ---
-        PATHS, BUTTON_PRESET, AXIS_PRESET = loadWorkSpace()
-        # Carica velocity (0-100%) e angle (gradi) dal file presetIndex/presetPath
-        self.velocity, self.angle = presetMenu(PATHS["presetIndex"], PATHS["presetPath"])
-        
-        self.paths = PATHS
-        self.presetButton = BUTTON_PRESET
-        self.presetAxis = AXIS_PRESET
-
-        self.config = readfile(os.getcwd()+"\\src\\data\\radioConfig.json")
+        self.paths, self.presetButton, self.presetAxis = loadWorkSpace()
+        self.velocity, self.angle = presetMenu(self.paths["presetIndex"], self.paths["presetPath"])
+        self.config = readfile(self.paths["dataPath"] + "/radioConfig.json")
 
         self.rc = RadioController()
         parser = argparse.ArgumentParser()
         parser.add_argument("port", nargs="?", default="COM13" if sys.platform == "win32" else "/dev/ttyUSB0")
         args = parser.parse_args()
 
-        self.rc.connect(args.port, self.config['SERIAL_BAUD'])
-        self.rc.handshake()
+        if not self.rc.connect(args.port, self.config["SERIAL_BAUD"]):
+            print(Fore.RED + f"ERRORE: connessione seriale fallita su {args.port}" + Style.RESET_ALL)
+            raise SystemExit(2)
+        if not self.rc.handshake():
+            print(Fore.RED + "ERRORE: handshake con TX fallito" + Style.RESET_ALL)
+            raise SystemExit(3)
 
-        # --- Configurazione Mappatura Hardware ---
-        #buttonMap(self.presetButton, self.presetAxis, button_list, axis_list, self.paths["configPath"])
         setUpVolante(self.js, button_list, axis_list, self.paths["configPath"])
-        
-        buttonMp, axisMp = loadMap(self.paths["configPath"])
+        self.buttons, self.axis = loadMap(self.paths["configPath"])
+        if not self._validate_mapping():
+            print(Fore.RED + "Mappatura non valida: rifai configurazione assi/pulsanti." + Style.RESET_ALL)
+            raise SystemExit(4)
+
         CLEAR()
         INIZIALISE(self.js)
-        
-        self.buttons = buttonMp
-        self.axis = axisMp
 
-        # --- Stato Interno ---
         self.running = True
         self.firstStart = True
         self.start = False
@@ -69,75 +74,146 @@ class Controller():
         self.selected = 0
         self.position = 0
         self.option_selected = options_list
-        
-        # SOGLIA DRIFT (Deadzone)
-        self.deadzone = 0.08  # Ignora input inferiori all'8%
 
-    def apply_deadzone(self, value):
-        """Applica zona morta e riscala l'input per fluidità."""
+        self.deadzone = 0.05
+        self.current_accel = 0.0
+        self.current_steer = 0.0
+        self.accel_rise_rate = 0.05
+        self.accel_fall_rate = 0.08
+        self.steer_rate = 0.10
+        self.last_debug_print = 0.0
+
+    def _connect_first_joystick(self):
+        for _ in range(20):
+            pygame.joystick.quit()
+            pygame.joystick.init()
+            if pygame.joystick.get_count() > 0:
+                js = pygame.joystick.Joystick(0)
+                js.init()
+                return js
+            time.sleep(0.1)
+        print(Fore.RED + "ERRORE: Nessun controller trovato." + Style.RESET_ALL)
+        pygame.quit()
+        raise SystemExit(1)
+
+    def _validate_mapping(self) -> bool:
+        required_btn = set(button_list)
+        required_axis = set(axis_list)
+        if not required_btn.issubset(self.buttons) or not required_axis.issubset(self.axis):
+            return False
+
+        max_buttons = self.js.get_numbuttons()
+        max_axes = self.js.get_numaxes()
+        if max_axes <= 0:
+            return False
+
+        for name in required_btn:
+            idx = self.buttons[name]
+            if idx < 0 or idx >= max_buttons:
+                return False
+        for name in required_axis:
+            idx = self.axis[name]
+            if idx < 0 or idx >= max_axes:
+                return False
+        return True
+
+    @staticmethod
+    def _clamp(value: float, low: float = -1.0, high: float = 1.0) -> float:
+        return max(low, min(high, value))
+
+    def apply_deadzone(self, value: float) -> float:
+        value = self._clamp(value)
         if abs(value) < self.deadzone:
             return 0.0
-        # Riscalatura: trasforma [deadzone, 1.0] in [0.0, 1.0]
-        return (value - (self.deadzone if value > 0 else -self.deadzone)) / (1.0 - self.deadzone)
+        scaled = (abs(value) - self.deadzone) / (1.0 - self.deadzone)
+        return scaled if value > 0 else -scaled
+
+    def normalize_trigger_axis(self, raw_value: float) -> float:
+        raw_value = self._clamp(raw_value)
+        return (raw_value + 1.0) / 2.0
+
+    def smooth_to_target(self, current: float, target: float, rise: float, fall: float) -> float:
+        if target > current:
+            return min(target, current + rise)
+        return max(target, current - fall)
+
+    def _safe_get_axis(self, name: str) -> float:
+        idx = self.axis.get(name, -1)
+        if idx < 0 or idx >= self.js.get_numaxes():
+            return 0.0
+        return self.js.get_axis(idx)
+
+    def _handle_device_event(self, event):
+        if event.type == pygame.JOYDEVICEREMOVED:
+            print(Fore.YELLOW + "Controller scollegato, attendo riconnessione..." + Style.RESET_ALL)
+            self.start = False
+        elif event.type == pygame.JOYDEVICEADDED:
+            self.js = self._connect_first_joystick()
+            print(Fore.GREEN + f"Controller riconnesso: {self.js.get_name()}" + Style.RESET_ALL)
 
     def run(self):
-        """Loop principale dell'applicazione."""
         while self.running:
             for event in pygame.event.get():
+                self._handle_device_event(event)
                 self.gestioneUscite(event)
                 self.gestioneBottoni(event)
                 self.gestioneAssi(event)
-            
-            # Invio dati binari se il sistema è attivo
+
+            pygame.event.pump()
+
             if self.start and not self.settings:
                 self.invioDati()
-                time.sleep(0.02) 
-                    
-        if self.rc: 
+                self.monitor_debug()
+                time.sleep(0.02)
+
+        if self.rc:
             self.rc.close()
         pygame.quit()
 
     def invioDati(self):
-        # 1. Lettura dei valori dagli assi con applicazione della Deadzone
-        # Pygame restituisce valori da -1.0 a 1.0
-        raw_steer = self.apply_deadzone(self.js.get_axis(self.axis["STEERING"]))
-        raw_accel = self.apply_deadzone(self.js.get_axis(self.axis["ACCELERATOR"]))
-        raw_brake = self.apply_deadzone(self.js.get_axis(self.axis["BRAKE"]))
+        steer_raw = self._safe_get_axis("STEERING")
+        accel_raw = self._safe_get_axis("ACCELERATOR")
+        brake_raw = self._safe_get_axis("BRAKE")
 
-        # 2. Mappatura dello sterzo (0-255, centro 128)
-        steer_byte = int((raw_steer + 1.0) / 2.0 * 255)
+        steer_target = self.apply_deadzone(steer_raw)
+        steer_limit = self.angle / 180.0
+        steer_target *= steer_limit
 
-        # 3. Mappatura Acceleratore con limite di potenza (self.velocity)
-        # Convertiamo l'input in 0-255 e poi lo scaliamo per la percentuale impostata
-        accel_raw = int((raw_accel + 1.0) / 2.0 * 255)
-        power_limit = self.velocity / 100.0
-        accel_byte = int(accel_raw * power_limit)
+        accel_target = self.normalize_trigger_axis(accel_raw)
+        brake_target = self.normalize_trigger_axis(brake_raw)
+        accel_target = max(0.0, accel_target - brake_target * 0.6)
 
-        # 4. Mappatura Freno
-        brake_byte = int((raw_brake + 1.0) / 2.0 * 255)
+        self.current_steer = self.smooth_to_target(self.current_steer, steer_target, self.steer_rate, self.steer_rate)
+        self.current_accel = self.smooth_to_target(self.current_accel, accel_target, self.accel_rise_rate, self.accel_fall_rate)
 
-        # 5. Vincoli di sicurezza (Clamp)
-        steer_byte = max(0, min(255, steer_byte))
-        accel_byte = max(0, min(255, accel_byte))
-        brake_byte = max(0, min(255, brake_byte))
+        steer_byte = int((self.current_steer + 1.0) * 127.5)
+        accel_byte = int(self.current_accel * 255 * (self.velocity / 100.0))
+        brake_active = brake_target > 0.15
 
-        # 6. Logica Freno e Retromarcia
-        # Consideriamo il freno "attivo" se premuto oltre una certa soglia
-        is_braking = brake_byte > 20 
-        
-        # 7. Invio dei dati tramite il modulo radio
-        # Passiamo 0 come 'speed_sel' perché la logica marce è stata eliminata
-        # e gestita direttamente dallo scaling dell'accel_byte qui sopra.
         self.rc.send_data(
-            steer=steer_byte, 
-            accel=accel_byte, 
-            brake=is_braking, 
-            speed_sel=0, 
-            reverse=self.retromarcia, 
-            commands=0
+            steer=max(0, min(255, steer_byte)),
+            accel=max(0, min(255, accel_byte)),
+            brake=brake_active,
+            speed_sel=0,
+            reverse=self.retromarcia,
+            commands=0,
         )
 
-    # --- Gestione Eventi ---
+    def monitor_debug(self):
+        now = time.monotonic()
+        for msg in self.rc.poll_messages():
+            if "ERR" in msg or "FAIL" in msg or "NO_RADIO" in msg:
+                print(Fore.RED + f"[TX/RX] {msg}" + Style.RESET_ALL)
+
+        if now - self.last_debug_print >= 1.0:
+            self.last_debug_print = now
+            fail_ratio = (self.rc.tx_fail / max(1, self.rc.tx_count)) * 100
+            print(Fore.CYAN + f"[DEBUG] sent={self.rc.tx_count} fail={self.rc.tx_fail} ({fail_ratio:.1f}%)" + Style.RESET_ALL)
+
+        if self.rc.has_serial_fault():
+            print(Fore.RED + "[ERRORE] Troppi errori seriali consecutivi, stop sicurezza." + Style.RESET_ALL)
+            self.start = False
+
     def gestioneUscite(self, event):
         if event.type == pygame.QUIT:
             self.running = False
@@ -147,18 +223,15 @@ class Controller():
     def gestioneBottoni(self, event):
         if event.type != pygame.JOYBUTTONDOWN:
             return
-        
+
         if event.button == self.buttons["RETRO_ON"]:
             self.retromarcia = True
             print(Fore.CYAN + "RETROMARCIA: ON" + Style.RESET_ALL)
-            
         elif event.button == self.buttons["RETRO_OFF"]:
             self.retromarcia = False
             print(Fore.CYAN + "RETROMARCIA: OFF" + Style.RESET_ALL)
-
         elif event.button == self.buttons["START"]:
             self.gestioneInizio()
-        
         elif event.button == self.buttons["EXIT"]:
             self.gestioneUsciteBottoni()
 
@@ -166,17 +239,16 @@ class Controller():
             self.gestioneBottoniImpostazioni(event)
         elif event.button == self.buttons["SETTINGS"] and not self.start:
             self.gestioneImpostazioni()
-    
+
     def gestioneAssi(self, event):
         if event.type != pygame.JOYAXISMOTION:
             return
 
-        # Navigazione menu impostazioni tramite assi
         if self.settings and self.selectItem:
-            if self.selected == 0: # Velocità
-                self.position, self.velocity = settingOption(event.value, self.position, 100, 0, self.velocity, self.selected, 0, 5, self.option_selected)
-            elif self.selected == 1: # Angolo
-                self.position, self.angle = settingOption(event.value, self.position, 180, 0, self.angle, self.selected, 1, 9, self.option_selected)
+            if self.selected == 0:
+                self.position, self.velocity = settingOption(event.value, self.position, 100, 1, self.velocity, self.selected, 0, 5, self.option_selected)
+            elif self.selected == 1:
+                self.position, self.angle = settingOption(event.value, self.position, 180, 1, self.angle, self.selected, 1, 9, self.option_selected)
 
     def gestioneInizio(self):
         if self.firstStart:
@@ -187,7 +259,7 @@ class Controller():
         else:
             self.start = not self.start
             drawMenu()
-    
+
     def gestioneUsciteBottoni(self):
         if not self.start and not self.settings:
             self.running = False
@@ -195,26 +267,24 @@ class Controller():
             self.settings = False
             self.selectItem = False
             drawMenu()
-            
+
     def gestioneImpostazioni(self):
         self.settings = True
         self.selected = 0
         drawSettings(self.selected, self.option_selected)
-    
+
     def gestioneBottoniImpostazioni(self, event):
         if event.button == self.buttons["UP"]:
             self.selectItem = False
             self.selected = max(0, self.selected - 1)
             drawSettings(self.selected, self.option_selected)
-
         elif event.button == self.buttons["DOWN"]:
             self.selectItem = False
             self.selected = min(len(self.option_selected) - 1, self.selected + 1)
             drawSettings(self.selected, self.option_selected)
-
         elif event.button == self.buttons["SELECT"]:
             self.gestioneOpzioniImpostazioni()
-    
+
     def gestioneOpzioniImpostazioni(self):
         if self.selectItem:
             self.selectItem = False
@@ -223,16 +293,19 @@ class Controller():
 
         self.selectItem = True
         CLEAR()
-        if self.selected == 2: # Reset Mappatura
+        if self.selected == 2:
             setUpVolante(self.js, button_list, axis_list, self.paths["configPath"])
             self.buttons, self.axis = loadMap(self.paths["configPath"])
             self.settings = False
             drawMenu()
-        elif self.selected == 3: # Salva Preset
+        elif self.selected == 3:
             presetMenu(self.paths["presetIndex"], self.paths["presetPath"], self.velocity, self.angle)
+            self.velocity, self.angle = reloadPreset(self.paths["presetIndex"], self.paths["presetPath"])
             self.selectItem = False
             drawSettings(self.selected, self.option_selected)
         else:
             drawSettings(self.selected, self.option_selected)
-            if self.selected == 0: drawSettingOption(0, 100, self.velocity, 5)
-            if self.selected == 1: drawSettingOption(0, 180, self.angle, 9)
+            if self.selected == 0:
+                drawSettingOption(1, 100, self.velocity, 5)
+            if self.selected == 1:
+                drawSettingOption(1, 180, self.angle, 9)

--- a/src/objRadio.py
+++ b/src/objRadio.py
@@ -1,71 +1,100 @@
+import os
+import struct
+import time
+
 import serial
-from src.utils import *
+
+from src.utils import crc16_ccitt, readfile
+
 
 class RadioController:
     def __init__(self):
-        self.config = readfile(os.getcwd()+"/src/data/radioConfig.json")
+        self.config = readfile(os.path.join(os.path.dirname(__file__), "data", "radioConfig.json"))
         self.ser: serial.Serial | None = None
         self.module = "UNKNOWN"
-        self.send_rate = self.config['DEFAULT_SEND_RATE']
-        self.tx_power = self.config['DEFAULT_TX_POWER']
+        self.send_rate = self.config["DEFAULT_SEND_RATE"]
+        self.tx_power = self.config["DEFAULT_TX_POWER"]
         self.connected = False
         self.tx_count = 0
         self.tx_fail = 0
+        self.consecutive_errors = 0
 
     def connect(self, port: str, baud: int) -> bool:
         try:
-            self.ser = serial.Serial(port, baud, timeout=0.1)
-            time.sleep(2)
+            self.ser = serial.Serial(port, baud, timeout=self.config.get("SERIAL_TIMEOUT_S", 0.1))
+            time.sleep(1.5)
             self.ser.reset_input_buffer()
             self.connected = True
+            self.consecutive_errors = 0
             return True
-        except Exception as e:
+        except Exception:
             self.connected = False
             return False
 
     def send_command(self, cmd: str) -> str | None:
-        if not self.ser: return None
+        if not self.ser:
+            return None
         try:
             self.ser.reset_input_buffer()
             self.ser.write((cmd + "\n").encode())
             time.sleep(0.15)
-            return self.ser.readline().decode(errors="replace").strip() or None
-        except Exception: return None
+            resp = self.ser.readline().decode(errors="replace").strip() or None
+            self.consecutive_errors = 0
+            return resp
+        except Exception:
+            self.consecutive_errors += 1
+            return None
 
     def handshake(self) -> bool:
-        resp = self.send_command("HANDSHAKE")
-        if resp and resp.startswith("ACK"):
-            self._parse_status(resp.split())
-            return True
+        for _ in range(3):
+            resp = self.send_command("HANDSHAKE")
+            if resp and resp.startswith("ACK"):
+                self._parse_status(resp.split())
+                return True
+            time.sleep(0.2)
         return False
 
     def _parse_status(self, parts: list[str]):
-        if len(parts) >= 2: self.module = parts[1]
-        if len(parts) >= 3: self.send_rate = int(parts[2])
-        if len(parts) >= 4: self.tx_power = int(parts[3])
+        if len(parts) >= 2:
+            self.module = parts[1]
+        if len(parts) >= 3:
+            self.send_rate = int(parts[2])
+        if len(parts) >= 4:
+            self.tx_power = int(parts[3])
 
     def send_data(self, steer: int, accel: int, brake: bool, speed_sel: int, reverse: bool, commands: int):
-        if not self.ser: return
+        if not self.ser:
+            self.tx_fail += 1
+            self.consecutive_errors += 1
+            return
 
         misc = ((speed_sel & 0x0F) << 4) | ((1 if brake else 0) << 3) | ((1 if reverse else 0) << 2) | (commands & 0x03)
         payload = struct.pack("BBB", steer, accel, misc)
         crc = crc16_ccitt(payload)
-        
-        frame = struct.pack("B", self.config['BINARY_MARKER']) + payload + struct.pack(">H", crc)
-        
+        frame = struct.pack("B", self.config["BINARY_MARKER"]) + payload + struct.pack(">H", crc)
+
         try:
             self.ser.write(frame)
-            self.ser.flush() 
+            self.ser.flush()
             self.tx_count += 1
-        except: 
+            self.consecutive_errors = 0
+        except Exception:
             self.tx_fail += 1
+            self.consecutive_errors += 1
 
     def poll_messages(self):
         msgs = []
-        while self.ser and self.ser.in_waiting:
+        read_budget = 10
+        while self.ser and self.ser.in_waiting and read_budget > 0:
             line = self.ser.readline().decode(errors="replace").strip()
-            if line: msgs.append(line)
+            if line:
+                msgs.append(line)
+            read_budget -= 1
         return msgs
 
+    def has_serial_fault(self) -> bool:
+        return self.consecutive_errors >= self.config.get("MAX_SERIAL_ERRORS", 8)
+
     def close(self):
-        if self.ser: self.ser.close()
+        if self.ser:
+            self.ser.close()

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,70 +1,74 @@
-import os
-from colorama import * 
-from datetime import *
 import json
-import pygame
-from art import *
+import os
 import time
-import struct
-      
+from datetime import datetime
+from pathlib import Path
+
+import pygame
+from art import text2art
+from colorama import Fore, Style
+
 BINARY_MARKER = 0xAA
 
 
-#---- Funzioni setUp ----
+def _repo_src_path() -> Path:
+    return Path(__file__).resolve().parent
+
 
 def setUpWorkSpace():
-    path = os.getcwd()+"\\src"
-    if not os.path.exists(path+"\\data"):
-        print(Fore.YELLOW + "Setting up workspace" + Style.RESET_ALL)
-        os.makedirs(path+"\\data")
-        os.makedirs(path+"\\data\\preset")
-        with open(path+"\\data\\preset\\preset0.json", "w") as f:
-            data = {
-                "maxVel": 50,
-                "maxAngle": 45
-            }
-            json.dump(data, f, indent=4)
+    src_path = _repo_src_path()
+    data_path = src_path / "data"
+    preset_path = data_path / "preset"
 
-        with open(path+"\\data\\preset\\indexPreset.json", "w") as f:
-            data = {
-                "presetNames": ["start"],
-                "preset": "start"
-            }
-            json.dump(data, f, indent=4)
+    data_path.mkdir(parents=True, exist_ok=True)
+    preset_path.mkdir(parents=True, exist_ok=True)
 
-        with open(path+"\\data\\setting.json", "w") as f:
-            data = {
-                "dateTime": str(datetime.now()),
-                "paths": {
-                    "homePath": path,
-                    "dataPath": path+"\\data",
-                    "settingPath": path+"\\data\\setting.json",
-                    "presetPath": path+"\\data\\preset",
-                    "presetIndex": path+"\\data\\preset\\indexPreset.json",
-                    "configPath": path+"\\data\\config.json"
-                },
-                "presetButton": ["12","5","3","0","1","4","9","8"],
-                "presetAxis": ["0","5","1"]
-            }
-            json.dump(data, f, indent=4)
-        
+    preset0 = preset_path / "preset0.json"
+    if not preset0.exists():
+        writefile(preset0, {"maxVel": 50, "maxAngle": 45})
+
+    index_preset = preset_path / "indexPreset.json"
+    if not index_preset.exists():
+        writefile(index_preset, {"presetNames": ["start"], "preset": "start"})
+
+    settings_path = data_path / "setting.json"
+    if not settings_path.exists():
         data = {
-            "SERIAL_BAUD": 115200,
-            "MAX_SPEEDS": 6,
-            "DISPLAY_REFRESH_S": 0.1,
-            "MAPPING_FILE": "mapping.json",
-            "DEFAULT_SEND_RATE": 30,
-            "BINARY_MARKER": 0xAA,
-            "DEFAULT_TX_POWER": 10
+            "dateTime": str(datetime.now()),
+            "paths": {
+                "homePath": str(src_path),
+                "dataPath": str(data_path),
+                "settingPath": str(settings_path),
+                "presetPath": str(preset_path),
+                "presetIndex": str(index_preset),
+                "configPath": str(data_path / "config.json"),
+            },
+            "presetButton": ["12", "5", "3", "0", "1", "4", "9", "8"],
+            "presetAxis": ["0", "5", "1"],
         }
-        writefile(path+"\\data\\radioConfig.json", data)
+        writefile(settings_path, data)
+
+    radio_config = data_path / "radioConfig.json"
+    if not radio_config.exists():
+        writefile(
+            radio_config,
+            {
+                "SERIAL_BAUD": 115200,
+                "DISPLAY_REFRESH_S": 0.1,
+                "DEFAULT_SEND_RATE": 30,
+                "BINARY_MARKER": 0xAA,
+                "DEFAULT_TX_POWER": 10,
+                "SERIAL_TIMEOUT_S": 0.1,
+                "MAX_SERIAL_ERRORS": 8,
+                "DEBUG_EVERY_N_PACKETS": 30,
+            },
+        )
 
 
 def scopri_assi(js, axis_names):
     print(f"\n  Mapping Assi per: {js.get_name()}")
-    nomi = axis_names
     assi = {}
-    for nome in nomi:
+    for nome in axis_names:
         print(f"  Muovi {nome}...", end="", flush=True)
         baseline = [js.get_axis(i) for i in range(js.get_numaxes())]
         found = False
@@ -78,14 +82,15 @@ def scopri_assi(js, axis_names):
                     found = True
                     time.sleep(0.5)
                     break
-        if not found: print(" Timeout!")
+        if not found:
+            print(" Timeout!")
     return assi
+
 
 def scopri_pulsanti(js, button_names):
     print("\n  Mapping Pulsanti...")
-    nomi = button_names
     btns = {}
-    for nome in nomi:
+    for nome in button_names:
         print(f"  Premi {nome}...", end="", flush=True)
         found = False
         t0 = time.time()
@@ -104,44 +109,39 @@ def scopri_pulsanti(js, button_names):
 def setUpVolante(js, button_names, axis_names, path):
     CLEAR()
     print(Fore.YELLOW + "Rilevamento hardware: " + js.get_name() + Style.RESET_ALL)
-    
-    if input("Modificare i valori di default? (y/n): ").lower() != "y":
+
+    config_path = Path(path)
+    if config_path.exists() and input("Modificare i valori di default? (y/n): ").lower() != "y":
         print(Fore.GREEN + "Valori di default mantenuti." + Style.RESET_ALL)
         return
 
     data = {"button": {}, "axis": {}}
 
-    
     print(Fore.CYAN + "\n--- CONFIGURAZIONE PULSANTI ---")
-    btns = scopri_pulsanti(js, button_names)
+    data["button"] = scopri_pulsanti(js, button_names)
 
     print(Fore.CYAN + "\n--- CONFIGURAZIONE ASSI ---")
-    assi = scopri_assi(js, axis_names)
+    data["axis"] = scopri_assi(js, axis_names)
 
-    data["button"] = btns
-    data["axis"] = assi
-
-    writefile(path, data)
+    writefile(config_path, data)
     print(Fore.GREEN + "\nMappatura salvata con successo!" + Style.RESET_ALL)
 
-#--- Funzioni di preset ---
 
+# --- Funzioni di preset ---
 def readfile(path):
     with open(path, "r", encoding="utf-8") as f:
-        data = json.load(f)
-    return data
+        return json.load(f)
+
 
 def writefile(path, data):
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=4)
 
+
 def loadWorkSpace():
     setUpWorkSpace()
-    data = readfile(os.getcwd()+"/src/data/setting.json")
-    PATHS = data["paths"]
-    BUTTON = data["presetButton"]
-    AXIS = data["presetAxis"]
-    return PATHS, BUTTON, AXIS
+    data = readfile(_repo_src_path() / "data" / "setting.json")
+    return data["paths"], data["presetButton"], data["presetAxis"]
 
 
 def get_int_input(prompt, min_val, max_val):
@@ -154,52 +154,49 @@ def get_int_input(prompt, min_val, max_val):
             pass
         print(f"Errore: inserire un numero tra {min_val} e {max_val}")
 
+
 def presetMenu(presetIndex, presetPath, vel=50, angle=45):
     CLEAR()
     print(Fore.YELLOW + "Gestione PRESET" + Style.RESET_ALL)
     print("\t1. Salva attuale\n\t2. Crea nuovo\n\t3. Carica esistente")
-    
+
     scelta = get_int_input("Opzione -> ", 1, 3)
-    
     if scelta == 1:
         savePreset(presetIndex, presetPath, vel, angle)
-    elif scelta == 2:
+        return reloadPreset(presetIndex, presetPath)
+    if scelta == 2:
         createPreset(presetIndex, presetPath, vel, angle)
-    else:
-        return loadPreset(presetIndex, presetPath)
+        return reloadPreset(presetIndex, presetPath)
+    return loadPreset(presetIndex, presetPath)
+
 
 def savePreset(presetIndex, presetPath, vel, angle):
     data = readfile(presetIndex)
     index = data["presetNames"].index(data["preset"])
-    
-    payload = {"maxVel": vel, "maxAngle": angle}
-    writefile(f"{presetPath}\\preset{index}.json", payload)
+    writefile(Path(presetPath) / f"preset{index}.json", {"maxVel": vel, "maxAngle": angle})
     print(Fore.GREEN + "Preset salvato correttamente!" + Style.RESET_ALL)
+
 
 def createPreset(presetIndex, presetPath, vel, angle):
     CLEAR()
     data = readfile(presetIndex)
     names = data["presetNames"]
 
-    # Validazione nome unico
     name = ""
     while not name or name in names:
         name = input("Inserisci un nome univoco per il preset: ").lower().strip()
-    
+
     names.append(name)
-    
+
     if input("Vuoi inserire i valori manualmente? (y/n): ").lower() == "y":
         vel = get_int_input("Velocità (1-100): ", 1, 100)
         angle = get_int_input("Angolo (1-180): ", 1, 180)
 
-    # Aggiorna indice nomi
     use_now = input("Usare subito questo preset? (y/n): ").lower() == "y"
     data["preset"] = name if use_now else data["preset"]
     writefile(presetIndex, data)
+    writefile(Path(presetPath) / f"preset{len(names)-1}.json", {"maxVel": vel, "maxAngle": angle})
 
-    # Salva file fisico del preset
-    save_data = {"maxVel": vel, "maxAngle": angle}
-    writefile(f"{presetPath}\\preset{len(names)-1}.json", save_data)
 
 def loadPreset(presetIndex, presetPath):
     data = readfile(presetIndex)
@@ -210,75 +207,32 @@ def loadPreset(presetIndex, presetPath):
         print(f"\t{i}. {name.capitalize()}")
 
     idx = get_int_input("\tScegli il numero del preset: ", 0, len(names) - 1)
-    
-    # Aggiorna il preset attivo nel file indice
     data["preset"] = names[idx]
     writefile(presetIndex, data)
 
-    # Carica i valori reali
     vel, angle = reloadPreset(presetIndex, presetPath)
     print(f"Caricato: {names[idx].upper()} (Vel: {vel}, Angolo: {angle})")
     return vel, angle
 
+
 def reloadPreset(presetIndex, presetPath):
     data_idx = readfile(presetIndex)
     idx = data_idx["presetNames"].index(data_idx["preset"])
-    
-    preset_data = readfile(f"{presetPath}\\preset{idx}.json")
+    preset_data = readfile(Path(presetPath) / f"preset{idx}.json")
     return preset_data["maxVel"], preset_data["maxAngle"]
 
 
-def configMenu(path):
-    print(Fore.YELLOW + "Menu di configurazione:" + Style.RESET_ALL)
-    if os.path.exists(path):
-        print(Fore.GREEN + "\nFile di configurazione trovato \n" + Style.RESET_ALL)
-    else:
-        print(Fore.GREEN + "\nFile di configurazione non trovato" + Style.RESET_ALL)
-        print(Fore.YELLOW + "\nCreazione di una configurazione:")
-        print("Configurazione:\n\t- Se il campo e vuoto viene caricato un preset\n\t- Se inserisci un valore verra creata una configurazione personalizata")
-        
-def buttonMap(presetButton, presetAxis, button, axis, path):
-    dataButton = {}
-    dataAxis = {}
-    data = {}
-    configMenu(path)
-    if not os.path.exists(path):
-        print(Fore.GREEN + "Configurazione buttoni:" + Style.RESET_ALL)
-        for idx, btn in enumerate(button):
-            btnValue = input(f"{btn}: ")
-            if btnValue == "":
-                btnValue = presetButton[idx]
-                print("Caricato preset con id", presetButton[idx])
-            dataButton.update({
-                btn: btnValue
-            })
-        print(Fore.GREEN + "Configurazione assi:" + Style.RESET_ALL)
-        for idx, x in enumerate(axis):
-            axisValue = input(f"{x}: ")
-            if axisValue == "":
-                axisValue = presetAxis[idx]
-                print("Caricato preset con id", presetAxis[idx])
-            dataAxis.update({
-                x: axisValue
-            })
-        data.update({
-            "button": dataButton,
-            "axis": dataAxis
-        })
-        with open(path, mode="w") as f:
-            json.dump(data, f, indent=4)
-
 def loadMap(path):
-    with open(path, mode="r") as f:
+    with open(path, mode="r", encoding="utf-8") as f:
         dati = json.load(f)
         buttons = {k: int(v) for k, v in dati["button"].items()}
         axis = {k: int(v) for k, v in dati["axis"].items()}
     return buttons, axis
 
-#---- Funzioni generali ----
 
 def CLEAR():
-    os.system('cls' if os.name == 'nt' else 'clear')
+    os.system("cls" if os.name == "nt" else "clear")
+
 
 def INIZIALISE(js):
     print(text2art("Squadra Corse", font="small"))
@@ -286,13 +240,12 @@ def INIZIALISE(js):
     print(f"\t- Volante rilevato: {js.get_name()}")
     print(f"\t- Numero di pulsanti: {js.get_numbuttons()}")
     print(f"\t- Numero di assi: {js.get_numaxes()}")
-    print(Fore.YELLOW+ "\nCLICCARE PULSANTE PS PER ANDARE AVANTI" + Style.RESET_ALL)
+    print(Fore.YELLOW + "\nCLICCARE PULSANTE PS PER ANDARE AVANTI" + Style.RESET_ALL)
 
-#---- Funzioni programma -----
 
 def drawMenu():
-    os.system('cls' if os.name == 'nt' else 'clear')
-    print(Fore.YELLOW +  "Menu principale:" + Style.RESET_ALL)
+    CLEAR()
+    print(Fore.YELLOW + "Menu principale:" + Style.RESET_ALL)
     print("\tQUADRATO - Impostazioni veicolo")
     print("\tPS button - Menu/start/stop veicolo")
     print(Fore.RED + "\tX - Seleziona exit" + Style.RESET_ALL)
@@ -300,50 +253,41 @@ def drawMenu():
 
 
 def drawSettings(slx, opt):
-    os.system('cls' if os.name == 'nt' else 'clear')
+    CLEAR()
     print("Impostazioni veicolo selezionate.")
     for idx, option in enumerate(opt, start=1):
         if idx - 1 == slx:
             print(Fore.YELLOW + f"\t> {idx}. {option} <" + Style.RESET_ALL)
-        else: 
+        else:
             print(f"\t{idx}. {option}")
-    print("Premi CERCHIO per selezionare l'opzione.")     
+    print("Premi CERCHIO per selezionare l'opzione.")
     print(Fore.RED + "Premi X per tornare al menu principale." + Style.RESET_ALL)
 
-def settingOption(value, position, max, min, var, id, idValue, subdivision, opt):
-    if value > 0 and value > position:
-        if var >= max:
-            var = max
-        else:
-            var += 1
-    else:
-        if var <= min:
-            var = min
-        else:
-            var -= 1
-    position= value
-    os.system('cls' if os.name == 'nt' else 'clear')
+
+def settingOption(value, position, max_val, min_val, var, id_opt, idValue, subdivision, opt):
+    var = min(max_val, var + 1) if value > 0 and value > position else max(min_val, var - 1)
+    position = value
+    CLEAR()
     print("Impostazioni veicolo selezionate.")
     for idx, option in enumerate(opt, start=1):
-        if idx - 1 == id:
+        if idx - 1 == id_opt:
             print(Fore.YELLOW + f"\t> {idx}. {option} <" + Style.RESET_ALL)
-            if id == idValue:
-                drawSettingOption(min, max, var, subdivision)
-        else: 
+            if id_opt == idValue:
+                drawSettingOption(min_val, max_val, var, subdivision)
+        else:
             print(f"\t{idx}. {option}")
     print("Premi CERCHIO per selezionare l'opzione.")
     print(Fore.RED + "Premi X per tornare al menu principale." + Style.RESET_ALL)
     return position, var
 
-def drawSettingOption(min, max, var, subdivision):
-    print(Fore.CYAN + f"\t   {min}" + Style.RESET_ALL, end=' ')
-    [print(Fore.CYAN + "|"+ Style.RESET_ALL, end='') for x in range(int(var / subdivision))]
-    [print("|", end='') for x in range(20-int(var/subdivision))]
-    print(Fore.CYAN+ f" {max} > {var}" + Style.RESET_ALL) 
 
-def showInfo(volante, acceleratore, freno):
-    print("VOLANTE: "+str(volante), "ACCELERATORE: "+str(acceleratore), "FRENO: "+ str(freno))
-            
+def drawSettingOption(min_val, max_val, var, subdivision):
+    print(Fore.CYAN + f"\t   {min_val}" + Style.RESET_ALL, end=" ")
+    print("|" * int(var / subdivision), end="")
+    print("|" * (20 - int(var / subdivision)), end="")
+    print(Fore.CYAN + f" {max_val} > {var}" + Style.RESET_ALL)
+
+
 def crc16_ccitt(data: bytes) -> int:
     crc = 0xFFFF
     for b in data:
@@ -352,4 +296,3 @@ def crc16_ccitt(data: bytes) -> int:
             crc = ((crc << 1) ^ 0x1021) if (crc & 0x8000) else (crc << 1)
             crc &= 0xFFFF
     return crc
-


### PR DESCRIPTION
### Motivation

- Make the radio link more robust and observable by adding sequencing, stronger CRC handling and better module autodetection for both TX and RX.
- Soften vehicle behaviour with smoothing on steering and motor commands and improve failsafe/link-timeout logic to avoid abrupt maneuvers.
- Modernise and harden the PC-side controller code to better manage joysticks, serial handshake and configuration file paths.

### Description

- Update packet format to include a sequence byte and move to 10-byte packets (`PACKET_SIZE = 10`), change token to `"VAL2"`, and adjust CRC computation to cover the new layout on both `TxCompleto.ino` and `RxCompleto.ino`.
- Improve radio initialization and parameters for LoRa and nRF24 (spreading factor, bandwidth, coding rate, preamble, sync word, `setAutoAck`, channel and retries) and add periodic module probe and module-change logging.
- Add packet sequencing, statistics counters (`statPktOk`, `statCrcErr`, `statTokenErr`, `statDup`, `statLost`) and duplicate/loss detection on RX, and add TX sequence counter `txSeq` with updated CRC placement on TX.
- Implement steering smoothing (`updateSteering`), motor smoothing and softened failsafe/link-timeout behaviour, plus a `hardStop()` helper; add configurable timing constants and optional debug stats printing in both sketches.
- Refactor PC-side Python: make workspace/file path handling robust in `src/utils.py`, improve joystick connection, mapping validation, input deadzone/normalisation and smoothing in `src/objController.py`, and harden serial handling, handshake retries, error counting and message polling in `src/objRadio.py`.
- Improve binary USB frame handling and payload timeout handling on TX to zero throttle on stale frames while preserving steering, plus statistics counters for sent/failed packets and USB CRC errors.

### Testing

- Compiled both ESP32 sketches (`TxCompleto.ino` and `RxCompleto.ino`) with the Arduino toolchain to verify no build errors (success).
- Ran Python static checks and linting (`flake8`/basic import checks) against the modified `src` package to validate syntax and imports (success).
- Exercised `RadioController` handshake/send routines via an automated serial unit test harness that mocks a serial port to validate command/response parsing and error counting (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a06d0cdd84833290e67d62877c99e0)